### PR TITLE
Add noreferrer attribute to external links for improved security

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
         <div class="line"></div>
         <p>
           <!-- Upload your Github profile below in href="https://github.com/profile..." -->
-          <a href="https://github.com/Ananyasingh2002" target="_blank"><svg xmlns="http://www.w3.org/2000/svg"
+          <a href="https://github.com/Ananyasingh2002" target="_blank" rel="noopener noreferrer">
+            <svg xmlns="http://www.w3.org/2000/svg"
               width="24" height="24" viewBox="0 0 24 24">
               <mask id="lineMdGithubLoop0" width="24" height="24" x="0" y="0">
                 <g fill="#fff">


### PR DESCRIPTION
I added the rel="noopener noreferrer" attribute to external links (<a> tags with target="_blank") for enhanced security and performance. This improvement ensures safer navigation to external websites like GitHub and LinkedIn, enhancing the overall user experience